### PR TITLE
Stop inserting extra ":" after protocol

### DIFF
--- a/lib/combinator.js
+++ b/lib/combinator.js
@@ -279,7 +279,7 @@ Combinator.prototype = {
                     
                     // figure out if the URL should be relative or absolute
                     if(!base && uri.host && (uri.href !== uri.host)) {
-                        base = (uri.protocol ? uri.protocol + ":" : "") + "//" + uri.host;
+                        base = (uri.protocol || "") + "//" + uri.host;
                     }
                     
                     // Make sure URL isn't starting with the combo prefix, double-comboing is no good

--- a/test/_specimens/issues/issue-14.html
+++ b/test/_specimens/issues/issue-14.html
@@ -1,3 +1,2 @@
 <script type="text/javascript" src="//www.yooga.com/wooga/nooga/pooga.js"></script>
 <script type="text/javascript" src="//www.yooga.com/rooga/tooga/kooga.js"></script>
-    

--- a/test/_specimens/issues/issue-16.html
+++ b/test/_specimens/issues/issue-16.html
@@ -1,0 +1,2 @@
+<script type="text/javascript" src="https://www.tooga.com/wooga/nooga/pooga.js"></script>
+<script type="text/javascript" src="https://www.tooga.com/rooga/tooga/kooga.js"></script>

--- a/test/test.issues.js
+++ b/test/test.issues.js
@@ -53,4 +53,26 @@ describe("Combinator", function() {
             });
         });
     });
+
+    describe("Issue 16", function() {
+        it("shouldn't inject an extra \":\" after the protocol", function(done) {
+            var combinator = new Combinator(
+                    Combinator.defaults({
+                        files : _lib.files("./test/_specimens/issues/issue-16.html")
+                    })
+                );
+            
+            combinator.run(function(error, results) {
+                var text = results[0].text;
+                
+                assert.equal(
+                    text,
+                    "<script src=\"https://www.tooga.com/combo?/wooga/nooga/pooga.js&/rooga/tooga/kooga.js\"></script>\n"
+                );
+                
+                done();
+            });
+        });
+    });
+
 });


### PR DESCRIPTION
Fixes #16

Introduced with switch from parseUri to url.parse :(
